### PR TITLE
Switch quest to new public repo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,4 +40,4 @@ dependencies:
         - git+https://github.com/ioam/parambokeh.git
         - git+https://github.com/ioam/holoviews.git
         - git+https://github.com/ioam/geoviews.git
-        - git+https://github.com/ContinuumIO/EarthSim-quest.git
+        - git+https://github.com/erdc/quest.git


### PR DESCRIPTION
Quest is now licensed as BSD. Switching to public repo until conda packages are available.