### PR TITLE
Simplify installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 
 stages:
   - test
+  - doc
   - name: doc
     if: branch = master AND type != pull_request
 
@@ -28,10 +29,9 @@ jobs:
         - pip install ioamdoit
         - conda env create -q
         - source activate earthsim
-        - python setup.py develop --no-deps
+        - doit develop_install
         - doit capture_conda_env
       script:
-        - doit develop_install
         - doit download_sample_data
         - travis_wait 60 doit all_tests
 
@@ -46,7 +46,6 @@ jobs:
     - <<: *default
       stage: doc
       script:
-        - doit develop_install
         - doit install_doc_dependencies
         - doit download_sample_data
         - travis_wait 60 doit docs
@@ -55,5 +54,5 @@ jobs:
         skip_cleanup: true
         github_token: $GITHUB_TOKEN
         local_dir: ./doc/_build/html
-        #on:
-        #  tags: true
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - export PATH="$HOME/miniconda/bin:$PATH"
         #######################
         - pip install ioamdoit
-        - conda env create -q
+        - conda env create
         - source activate earthsim
         - doit develop_install
         - doit capture_conda_env

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: generic
 
 stages:
   - test
-  - doc
   - name: doc
     if: branch = master AND type != pull_request
 

--- a/dodo.py
+++ b/dodo.py
@@ -9,27 +9,12 @@ from ioamdoit import *
 # installing dependencies, running tests, downloading data, etc,
 # across projects.
 
-def task_develop_install():
-    return {'actions': [],
-            'task_dep': ['install_test_dependencies']}
-
-def task_install_required_dependencies():
-    return {'actions': []}
-
-def task_install_test_dependencies():
-    return {'actions': ['pip install pytest-nbsmoke',
-                        # Six installed twice remove and reinstall
-                        'pip uninstall six -y',
-                        'conda install six --yes'],
-            'task_dep': ['install_required_dependencies']}
-
 def task_test_nb():
     return {'actions': ['pytest --nbsmoke-run examples/']}
 
 def task_all_tests():
     return {'actions': [],
             'task_dep': ['test_nb']}
-
 
 
 ############################################################
@@ -42,7 +27,7 @@ def task_all_tests():
 def task_install_doc_dependencies():
     return {
         'actions': [
-            'conda install -y -q -c conda-forge sphinx beautifulsoup4 graphviz selenium phantomjs',
+            'conda install -y -c conda-forge "sphinx<1.7" beautifulsoup4 graphviz selenium phantomjs',
             'pip install nbsite sphinx_ioam_theme'],
         }
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,11 +19,9 @@ dependencies:
     - werkzeug
     - peewee
     - geopandas
-    - stevedore>1.6 # avoid getting from erdc channel
     - psutil
     - pint
     - pony
-    - pytest-cov
     - scikit-image
     - go-spatial
     - jupyter
@@ -35,9 +33,14 @@ dependencies:
     - gssha
     - datashader
     - filigree
-    - nbsmoke
     - param
     - parambokeh
+    ### dependencies for tests
+    - nbsmoke
+    - pytest-cov
+    ### dependencies for pip installed packages
+    # for quest
+    - stevedore>1.6 # avoid getting from erdc channel
 
     - pip:
         - git+https://github.com/ioam/paramnb.git

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: earthsim
 channels:
+    - pyviz/label/dev
     - ioam
     - erdc
     - bokeh
@@ -34,11 +35,12 @@ dependencies:
     - gssha
     - datashader
     - filigree
+    - nbsmoke
+    - param
+    - parambokeh
 
     - pip:
-        - git+https://github.com/ioam/param.git
         - git+https://github.com/ioam/paramnb.git
-        - git+https://github.com/ioam/parambokeh.git
         - git+https://github.com/ioam/holoviews.git
         - git+https://github.com/ioam/geoviews.git
         - git+https://github.com/erdc/quest.git

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
     - werkzeug
     - peewee
     - geopandas
-    - stevedore
+    - stevedore>1.6 # avoid getting from erdc channel
     - psutil
     - pint
     - pony


### PR DESCRIPTION
This is not a huge simplification - just some minor things for now.

* Use more conda packages instead of pip github master installs 
* Only deploy docs for a tag (tag format not restricted; assuming for now we'll only push tags for releases).
* Use ioamdoit's "develop_install" (earthsim's develop install task was empty, as it was added before there was a package to install)
* Avoid apparently bad stevedore package from erdc channel
* Started to categorize dependencies (#11)
* Work around https://github.com/ioam/nbsite/issues/35