### PR TITLE
Use conda for paramnb rather than pip.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
     - filigree
     - param
     - parambokeh
+    - paramnb
     ### dependencies for tests
     - nbsmoke
     - pytest-cov
@@ -43,7 +44,6 @@ dependencies:
     - stevedore
 
     - pip:
-        - git+https://github.com/ioam/paramnb.git
         - git+https://github.com/ioam/holoviews.git
         - git+https://github.com/ioam/geoviews.git
         - git+https://github.com/erdc/quest.git


### PR DESCRIPTION
I haven't checked that the relevant notebooks still work. 

The only test of the paramnb conda package is that it results in `import paramnb` succeeding.