### PR TITLE
Allow any recent python 3.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,10 @@ channels:
     - ioam
     - bokeh
     - conda-forge
-    - erdc    
+    - erdc
     - defaults
 dependencies:
-    - python=3.5
+    - python>=3.5
     - fiona
     - rasterio
     - gdal


### PR DESCRIPTION
My understanding is that things should work for python 2.7 or python 3. However, in the earthsim example environment, we'll be pinning things to a set of tested, known-to-work-well-together packages. We already know python 3.5 works; this change lets us try python 3.6 too.

Meanwhile, when we release an earthsim conda package, it can hopefully be much less constrained.