### PR TITLE
Work around recent travis/ghpages issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ jobs:
         - doit download_sample_data
         - travis_wait 60 doit docs
       deploy:
+        edge:
+          branch: v1.8.47
         provider: pages
         skip_cleanup: true
         github_token: $GITHUB_TOKEN


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/9312.

For most repositories, waiting for the issue to be fixed should be fine, but the earthsim and pyviz websites are both currently being updated.

Can't see that it's worked in this PR until after merging, but the same fix was applied at https://github.com/pyviz/pyviz/pull/44, and it worked there.