### PR TITLE
Allow defining path_type and crs on Annotator classes

### DIFF
--- a/earthsim/analysis.py
+++ b/earthsim/analysis.py
@@ -73,7 +73,10 @@ class LineCrossSection(param.Parameterized):
         a variable number of elements batching must be enabled and
         the legend_limit must be set to 0.
         """
-        path = self.path_stream.element
+        if self.path_stream.data is None:
+            path = self.path
+        else:
+            path = self.path_stream.element
         if isinstance(obj, TriMesh): 
             vdim = obj.nodes.vdims[0]
         else:
@@ -152,7 +155,10 @@ class SurfaceCrossSection(LineCrossSection):
         Rasterizes the supplied object across times returning
         an Image of the sampled data across time and distance.
         """
-        path = self.path_stream.element
+        if self.path_stream.data is None:
+            path = self.path
+        else:
+            path = self.path_stream.element
         if isinstance(obj, TriMesh): 
             vdim = obj.nodes.vdims[0]
         else:

--- a/earthsim/analysis.py
+++ b/earthsim/analysis.py
@@ -35,10 +35,11 @@ class LineCrossSection(param.Parameterized):
         Distance between samples in meters. Used for interpolation
         of the cross-section paths.""")
 
-    def __init__(self, obj, **params):
+    def __init__(self, obj, paths=None, **params):
         super(LineCrossSection, self).__init__(**params)
         self.obj = obj
-        self.path = Path([])
+        paths = [] if paths is None else paths
+        self.path = Path(paths, crs=ccrs.GOOGLE_MERCATOR)
         self.path_stream = PolyDraw(source=self.path)
         PolyEdit(source=self.path)
         self.sections = Dynamic(self.obj, operation=self._sample,

--- a/earthsim/annotators.py
+++ b/earthsim/annotators.py
@@ -46,7 +46,7 @@ class GeoAnnotator(param.Parameterized):
         self.polys = self.path_type(polys, crs=crs)
         self.poly_stream = PolyDraw(source=self.polys, data={})
         self.vertex_stream = PolyEdit(source=self.polys)
-        self.points = Points(points, crs=crs)
+        self.points = Points(points, self.polys.kdims, crs=crs)
         self.point_stream = PointDraw(source=self.points, data={})
 
     def pprint(self):
@@ -185,7 +185,7 @@ class PolyAnnotator(GeoAnnotator):
     def view(self):
         sel_stream = Selection1D(source=self.poly_table)
         poly_view = DynamicMap(self.highlight_polys, streams=[sel_stream])
-        return (self.tiles * self.polys * poly_view *
+        return (self.tiles * self.polys * poly_view.options(apply_ranges=False) *
                 self.points + self.poly_table).cols(1)
 
 
@@ -222,5 +222,5 @@ class PolyAndPointAnnotator(PolyAnnotator, PointAnnotator):
     """
 
     def view(self):
-        return (self.tiles * self.polys * self.poly_view * self.points +
+        return (self.tiles * self.polys * self.poly_view.options(apply_ranges=False) * self.points +
                 self.poly_table + self.point_table).cols(1)

--- a/earthsim/annotators.py
+++ b/earthsim/annotators.py
@@ -12,7 +12,7 @@ import cartopy.crs as ccrs
 import holoviews as hv
 from holoviews import DynamicMap, Path, Table, NdOverlay
 from holoviews.streams import Selection1D, Stream, PolyDraw, PolyEdit, PointDraw, CDSStream
-from geoviews import Polygons, Points, WMTS, TriMesh
+from geoviews import Path, Polygons, Points, WMTS, TriMesh
 
 
 class GeoAnnotator(param.Parameterized):
@@ -25,6 +25,9 @@ class GeoAnnotator(param.Parameterized):
 
     extent = param.NumericTuple(default=(-91, 32.2, -90.8, 32.4), doc="""
          Initial extent if no data is provided.""", precedence=-1)
+
+    path_type = param.ClassSelector(default=Polygons, class_=Path, doc="""
+         The element type to draw into.""")
 
     height = param.Integer(default=500, doc="Height of the plot",
                            precedence=-1)
@@ -39,7 +42,7 @@ class GeoAnnotator(param.Parameterized):
                           crs=ccrs.PlateCarree()).opts(plot=plot_opts)
         polys = [] if polys is None else polys
         points = [] if points is None else points
-        self.polys = Polygons(polys, crs=ccrs.GOOGLE_MERCATOR)
+        self.polys = self.path_type(polys, crs=ccrs.GOOGLE_MERCATOR)
         self.poly_stream = PolyDraw(source=self.polys, data={})
         self.vertex_stream = PolyEdit(source=self.polys)
         self.points = Points(points, crs=ccrs.GOOGLE_MERCATOR)
@@ -176,7 +179,7 @@ class PolyAnnotator(GeoAnnotator):
     def highlight_polys(self, index):
         polys = self.poly_stream.element.split(datatype='array')
         selected = [arr for i, arr in enumerate(polys) if i in index]
-        return Polygons(selected, crs=ccrs.GOOGLE_MERCATOR).opts(style=dict(fill_alpha=1))
+        return self.path_type(selected, crs=ccrs.GOOGLE_MERCATOR).opts(style=dict(fill_alpha=1))
 
     def view(self):
         sel_stream = Selection1D(source=self.poly_table)

--- a/earthsim/annotators.py
+++ b/earthsim/annotators.py
@@ -12,7 +12,7 @@ import cartopy.crs as ccrs
 import holoviews as hv
 from holoviews import DynamicMap, Path, Table, NdOverlay
 from holoviews.streams import Selection1D, Stream, PolyDraw, PolyEdit, PointDraw, CDSStream
-from geoviews import Path, Polygons, Points, WMTS, TriMesh
+from geoviews import Polygons, Points, WMTS, TriMesh
 
 
 class GeoAnnotator(param.Parameterized):
@@ -26,7 +26,7 @@ class GeoAnnotator(param.Parameterized):
     extent = param.NumericTuple(default=(-91, 32.2, -90.8, 32.4), doc="""
          Initial extent if no data is provided.""", precedence=-1)
 
-    path_type = param.ClassSelector(default=Polygons, class_=Path, doc="""
+    path_type = param.ClassSelector(default=Polygons, class_=Path, is_instance=False, doc="""
          The element type to draw into.""")
 
     height = param.Integer(default=500, doc="Height of the plot",
@@ -35,17 +35,18 @@ class GeoAnnotator(param.Parameterized):
     width = param.Integer(default=900, doc="Width of the plot",
                           precedence=-1)
 
-    def __init__(self, polys=None, points=None, **params):
+    def __init__(self, polys=None, points=None, crs=None, **params):
         super(GeoAnnotator, self).__init__(**params)
         plot_opts = dict(height=self.height, width=self.width)
         self.tiles = WMTS(self.tile_url, extents=self.extent,
                           crs=ccrs.PlateCarree()).opts(plot=plot_opts)
         polys = [] if polys is None else polys
         points = [] if points is None else points
-        self.polys = self.path_type(polys, crs=ccrs.GOOGLE_MERCATOR)
+        crs = ccrs.GOOGLE_MERCATOR if crs is None else crs
+        self.polys = self.path_type(polys, crs=crs)
         self.poly_stream = PolyDraw(source=self.polys, data={})
         self.vertex_stream = PolyEdit(source=self.polys)
-        self.points = Points(points, crs=ccrs.GOOGLE_MERCATOR)
+        self.points = Points(points, crs=crs)
         self.point_stream = PointDraw(source=self.points, data={})
 
     def pprint(self):

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
     - bokeh
     - conda-forge
     - erdc
+    - pyviz
     - defaults
 dependencies:
     - python>=3.5
@@ -35,6 +36,7 @@ dependencies:
     - filigree
     - param
     - parambokeh
+    - pyviz_comms      # parambokeh does not yet declare this dependency
     - paramnb
     - numpy=1.13       # Pinned to avoid warnings with numpy=1.14 and bokeh=1.12.14    
     ### dependencies for tests

--- a/examples/user_guide/Analyzing_Meshes.ipynb
+++ b/examples/user_guide/Analyzing_Meshes.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Very often there will be specific regions of a set of results that are the most of interest, and in those cases it can be helpful to pull out a particular region's data for visualization in a clearer way.  The ``LineCrossSection`` and ``SurfaceCrossSection`` classes allow taking cross-sections of a mesh (or some other rasterizable object) along poly-lines drawn using the ``PolyDraw`` tool, letting you make an *x*/*z* or *x*/*z*/*t* plot from data laid out in *x*/*y*/*z* or *x*/*y*/*z*/*t* (respectively). These classes rasterize the data at a fixed resolution, and then sample the data at that resolution given the underlying polylines. The ``resolution`` may be defined in the units of the underlying coordinate system."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -28,22 +35,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook provides a demo of ``LineCrossSection`` and ``SurfaceCrossSection`` helpers which allows taking cross-sections of a mesh along linestrings drawn using the ``PolyDraw`` tool. The helper rasterize the data at a fixed resolution and then samples the data at the same resolution given the underlying line strings. The ``resolution`` may be defined in the units of the underlying\n",
-    "coordinate system."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Example 1: A static TriMesh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As a simple example we will pass the static TriMesh to the ``CrossSector`` and display it. If now draw poly lines on the plot (left) we can see the depth along the path appear on the right."
+    "## Example 1: A static TriMesh\n",
+    "\n",
+    "As a first simple example, we will pass a static TriMesh to the ``LineCrossSection`` and display it. We'll pass a couple of sample polylines to start with, and if a live Python process is available we will be able to see the depth along the paths appear on the right, for those paths and any more that are subsequently drawn by the user."
    ]
   },
   {
@@ -52,27 +46,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = '../data/Chesapeake_and_Delaware_Bays.3dm'\n",
-    "tris, verts = read_3dm_mesh(path)\n",
+    "filename = '../data/Chesapeake_and_Delaware_Bays.3dm'\n",
+    "\n",
+    "cb_paths = [dict(Longitude = [-8523594, -8476533, -8449931, -8435409],\n",
+    "                 Latitude  = [ 4588993,  4578872,  4562126,  4539747]),\n",
+    "            dict(Longitude = [-8477265, -8469725], \n",
+    "                 Latitude  = [ 4544109 , 4430387])]\n",
+    "\n",
+    "tris, verts = read_3dm_mesh(filename)\n",
     "points = gv.operation.project_points(gv.Points(verts, vdims=['z']))\n",
     "trimesh = hv.TriMesh((tris, points))\n",
     "\n",
-    "sector = LineCrossSection(trimesh)\n",
-    "sector.view()"
+    "sector1 = LineCrossSection(trimesh, cb_paths)\n",
+    "sector1.view()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 2: A time-varying mesh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The ``CrossSector`` also allows working with time-varying meshes. Here we will modify the static TriMesh data with a time-varying random offset to demonstrate that the ``CrossSector`` works even for data that is evolving temporally."
+    "Each individual polyline (thick black connected line segments) on the left should result in one curve on the right, with a colored dot on that path corresponding to the color of the curve.  The location of the dot will change as you hover in the plot on the right, allowing you to see which value in the curve corresponds to which location along the polyline.\n",
+    "\n",
+    "## Example 2: A time-varying mesh\n",
+    "\n",
+    "``LineCrossSection`` also allows working with time-varying meshes. Here we will modify the static TriMesh data with a time-varying random offset to demonstrate that the ``LineCrossSection`` also works for data that is evolving temporally."
    ]
   },
   {
@@ -81,13 +78,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpath = '../data/SanDiego_Mesh/SanDiego.3dm'\n",
-    "tris, verts = read_3dm_mesh(fpath, skiprows=2)\n",
+    "sd_paths = [dict(Longitude = [-13037161, -13041435, -13045822, -13048664, -13050429, -13048385, -13048027],\n",
+    "                 Latitude  = [  3843454,   3854275,   3857996,   3857210,   3855575,   3849452,   3847896]),\n",
+    "            dict(Longitude = [-13042975, -13063919], \n",
+    "                 Latitude  = [  3850040,   3844636])]\n",
+    "\n",
+    "filename = '../data/SanDiego_Mesh/SanDiego.3dm'\n",
+    "tris, verts = read_3dm_mesh(filename, skiprows=2)\n",
     "points = gv.operation.project_points(gv.Points(verts, vdims=['z'], crs=ccrs.UTM(11)))\n",
     "trimesh = gv.TriMesh((tris, points))\n",
     "\n",
-    "fpath = '../data/SanDiego_Mesh/SanDiego_ovl.dat'\n",
-    "dfs = read_mesh2d(fpath)\n",
+    "filename2 = '../data/SanDiego_Mesh/SanDiego_ovl.dat'\n",
+    "dfs = read_mesh2d(filename2)\n",
     "\n",
     "points = gv.operation.project_points(gv.Points((verts.x, verts.y), crs=ccrs.UTM(11)))\n",
     "\n",
@@ -104,22 +106,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sector = LineCrossSection(meshes, resolution=100)\n",
-    "sector.view(cmap=cm_n.rainbow, shade=True)"
+    "sector2 = LineCrossSection(meshes, sd_paths, resolution=100)\n",
+    "sector2.view(cmap=cm_n.rainbow_r, shade=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 3: Sampling a Surface"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Instead of sampling individual Curve elements for each time, we can also take cross-sections across time returning an Image plotting the sampled value across both distance and time. Here we will subclass the ``CrossSector`` and override the ``sample`` method to apply the sampling for all time values and return an ``Image``."
+    "You can use the scrubber controls to animate both plots, showing both the map-based data and the curve cross sections over time.\n",
+    "\n",
+    "## Example 3: Sampling a Surface\n",
+    "\n",
+    "Instead of sampling individual Curve elements for each time as in example 2, we can take cross-sections across time, returning an Image plotting the sampled value across both distance and time. The ``SurfaceCrossSection`` class is a simple subclass of ``LineCrossSection`` that overrides the ``sample`` method to apply the sampling for all time values and return an ``Image``."
    ]
   },
   {
@@ -128,8 +127,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sector = SurfaceCrossSection(meshes, resolution=100)\n",
-    "sector.view(cmap=cm_n.rainbow, shade=False)"
+    "sector3 = SurfaceCrossSection(meshes, sd_paths[:1], resolution=100)\n",
+    "sector3.view(cmap=cm_n.rainbow_r, shade=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The scrubber will now only animate the plot on the left, as time has been laid out vertically on the plot on the right. \n",
+    "\n",
+    "If you have a running Python process and want to draw your own line, first delete the existing one, because an overlay of non-transparent images will only show the one on top."
    ]
   }
  ],

--- a/examples/user_guide/Analyzing_Meshes.ipynb
+++ b/examples/user_guide/Analyzing_Meshes.ipynb
@@ -48,11 +48,10 @@
    "source": [
     "filename = '../data/Chesapeake_and_Delaware_Bays.3dm'\n",
     "\n",
-    "cb_paths = [dict(Longitude = [-8523594, -8476533, -8449931, -8435409],\n",
-    "                 Latitude  = [ 4588993,  4578872,  4562126,  4539747]),\n",
-    "            dict(Longitude = [-8477265, -8469725], \n",
-    "                 Latitude  = [ 4544109 , 4430387])]\n",
-    "\n",
+    "cb_paths = [[(-8523594.,  4588993.), (-8476533.,  4578872.),\n",
+    "             (-8449931.,  4562126.), (-8435409.,  4539747.)],\n",
+    "            [(-8477265.,  4544109.), (-8469725.,  4430387.)]]\n",
+    "            \n",
     "tris, verts = read_3dm_mesh(filename)\n",
     "points = gv.operation.project_points(gv.Points(verts, vdims=['z']))\n",
     "trimesh = hv.TriMesh((tris, points))\n",
@@ -78,10 +77,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sd_paths = [dict(Longitude = [-13037161, -13041435, -13045822, -13048664, -13050429, -13048385, -13048027],\n",
-    "                 Latitude  = [  3843454,   3854275,   3857996,   3857210,   3855575,   3849452,   3847896]),\n",
-    "            dict(Longitude = [-13042975, -13063919], \n",
-    "                 Latitude  = [  3850040,   3844636])]\n",
+    "sd_paths = [\n",
+    "    [(-13037161.,   3843454.), (-13041435.,   3854275.), (-13045822.,   3857996.),\n",
+    "     (-13048664.,   3857210.), (-13050429.,   3855575.), (-13048385.,   3849452.),\n",
+    "     (-13048027.,   3847896.)],\n",
+    "    [(-13042975.,   3850040.), (-13063919.,   3844636.)]\n",
+    "]\n",
     "\n",
     "filename = '../data/SanDiego_Mesh/SanDiego.3dm'\n",
     "tris, verts = read_3dm_mesh(filename, skiprows=2)\n",
@@ -97,7 +98,8 @@
     "    depth_points = points.add_dimension('Velocity', 0, dfs[time].values[:, 0], vdim=True)\n",
     "    return gv.TriMesh((tris, depth_points), crs=ccrs.GOOGLE_MERCATOR)\n",
     "\n",
-    "meshes = hv.DynamicMap(time_mesh, kdims='Time').redim.values(Time=sorted(dfs.keys()))"
+    "time_dim = hv.Dimension('Time', values=sorted(dfs.keys()), default=3600)\n",
+    "meshes = hv.DynamicMap(time_mesh, kdims=time_dim)"
    ]
   },
   {

--- a/examples/user_guide/Specifying_Meshes.ipynb
+++ b/examples/user_guide/Specifying_Meshes.ipynb
@@ -18,7 +18,7 @@
     "import cartopy.crs as ccrs\n",
     "import parambokeh\n",
     "\n",
-    "from earthsim.annotators import PointAnnotator, GeoAnnotator\n",
+    "from earthsim.annotators import PolyAndPointAnnotator\n",
     "from earthsim.filigree import FiligreeMesh, FiligreeMeshDashboard\n",
     "\n",
     "hv.extension('bokeh')"
@@ -42,8 +42,8 @@
    "source": [
     "%%opts Polygons (color='red' alpha=0.5 selection_alpha=0.8 nonselection_alpha=0.2) \n",
     "%%opts Points (size=10 nonselection_alpha=0.5)\n",
-    "bounds = hv.Bounds(gv.util.project_extents(PointAnnotator.extent, ccrs.PlateCarree(), ccrs.GOOGLE_MERCATOR))\n",
-    "annot = PointAnnotator(polys=[bounds])\n",
+    "bounds = hv.Bounds(gv.util.project_extents(PolyAndPointAnnotator.extent, ccrs.PlateCarree(), ccrs.GOOGLE_MERCATOR))\n",
+    "annot = PolyAndPointAnnotator(polys=[bounds])\n",
     "annot.view()"
    ]
   },
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts RGB [width=900 height=600] (node_size=0 edge_line_width=0.1)\n",
+    "%%opts RGB [width=900 height=600]\n",
     "%%opts Points (size=10 color='blue') [tools=['hover']]\n",
     "mesh = FiligreeMesh(draw_helper=annot)\n",
     "mesh.mesh.create_constant_size_function(500, 5)\n",
@@ -87,7 +87,7 @@
    "source": [
     "%%opts Polygons (color='red' alpha=0.5 selection_alpha=0.8 nonselection_alpha=0.2) Layout [shared_datasource=True]\n",
     "%%opts Points (size=10 nonselection_alpha=0.5)\n",
-    "annot = PointAnnotator()\n",
+    "annot = PolyAndPointAnnotator()\n",
     "dashboard = FiligreeMeshDashboard(draw_helper=annot)\n",
     "dashboard.mesh.create_constant_size_function(500, 5)\n",
     "dashboard.mesh.set_outside_mesh_size(500)\n",
@@ -104,6 +104,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
    "pygments_lexer": "ipython3"

--- a/examples/user_guide/Visualizing_Meshes.ipynb
+++ b/examples/user_guide/Visualizing_Meshes.ipynb
@@ -201,7 +201,7 @@
     "    vy = velocity_dfs[time].values[:, 1]\n",
     "    xs, ys = (points.dimension_values(i) for i in range(2))\n",
     "    with np.errstate(divide='ignore', invalid='ignore'):\n",
-    "        angle = np.arctan(vy/vx)\n",
+    "        angle = np.arctan2(vy, vx)\n",
     "    mag = np.sqrt(vx**2+vy**2)\n",
     "    return gv.VectorField((xs, ys, angle, mag), vdims=['Angle', 'Magnitude'],\n",
     "                          crs=ccrs.GOOGLE_MERCATOR)\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
 [pytest]
 # when running, seconds allowed per cell (see nbconvert timeout)
 cell_timeout = 1800
+
+# notebooks to skip running; one case insensitive re to match per line
+skip_run = ^.*GSSHA.*\.ipynb$
+
+nbsmoke_skip_run = ^.*GSSHA.*\.ipynb$


### PR DESCRIPTION
Improves the Annotator classes a bit by allowing a user to define:

* path_type: To switch between drawing gv.Polygons and gv.Path types
* crs: Declare the coordinate system for the annotations