### PR TITLE
Simplified PolyAnnotator

### DIFF
--- a/earthsim/annotators.py
+++ b/earthsim/annotators.py
@@ -163,9 +163,10 @@ class PolyAnnotator(GeoAnnotator):
         plot = dict(width=self.width, height=self.table_height)
         self.polys.data = poly_to_geopandas(self.polys, self.poly_columns)
         self.polys.interface = GeoPandasInterface
-        poly_data = gv.project(self.polys).split()
-        self.poly_stream.event(data={kd.name: [p.dimension_values(kd) for p in poly_data]
-                                     for kd in self.polys.kdims})
+        if len(self.polys):
+            poly_data = gv.project(self.polys).split()
+            self.poly_stream.event(data={kd.name: [p.dimension_values(kd) for p in poly_data]
+                                         for kd in self.polys.kdims})
         self.poly_table = Table(self.polys.data, self.poly_columns, []).opts(plot=plot, style=style)
 
     def view(self):

--- a/earthsim/filigree.py
+++ b/earthsim/filigree.py
@@ -157,8 +157,9 @@ class FiligreeMeshDashboard(FiligreeMesh):
         helper = self.draw_helper
         mesh_dmap = DynamicMap(Callable(self.gen_mesh, memoize=False), streams=[self])
         if isinstance(helper, PolyAnnotator):
-            return (helper.tiles * helper.polys * helper.poly_view * mesh_dmap * helper.points +
-                    helper.poly_table + helper.point_table).cols(1)
+            layout = (helper.tiles * helper.polys * mesh_dmap * helper.points +
+                      helper.poly_table + helper.point_table)
         else:
-            return (helper.tiles * helper.polys * mesh_dmap * helper.points +
-                    helper.point_table).cols(1)
+            layout = (helper.tiles * helper.polys * mesh_dmap * helper.points +
+                      helper.point_table)
+        return layout.options(shared_datasource=True, clone=False).cols(1)

--- a/examples/user_guide/Annotators.ipynb
+++ b/examples/user_guide/Annotators.ipynb
@@ -210,6 +210,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "When we inspect the stream data we can see that three columns are made available, the 'xs' and 'ys' containing the vertices of each polygon/path and the Group annotation column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annot.poly_stream.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## PolyAndPointAnnotator\n",
     "\n",
     "The ``PolyAndPointAnnotator`` combines the ``PointAnnotator`` and ``PolyAnnotator``, showing two tables to add annotations to both the points and the polygons."
@@ -236,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "annot.poly_table_stream.data"
+    "annot.poly_stream.data"
    ]
   },
   {


### PR DESCRIPTION
Simplifies PolyAnnotator by removing complex syncing logic and instead using a shared_datasource in the form of a geopandas dataframe. The PointAnnotator and PolyAnnotator are now much more similar to each other and we can start building more complex things on top of the annotator classes.