### PR TITLE
Fix problem with old/deprecated (?) gcc clobbering libstdcxx-ng on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ jobs:
         - source activate earthsim
         - doit develop_install
         - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
-        - conda remove -y --force gcc
-        - conda install -y --force -c conda-forge libgcc-ng scipy numpy libstdcxx-ng
+        - rm -rf /home/travis/miniconda/envs/earthsim/lib/libstdc++.so.6
+        - ln -s /home/travis/miniconda/envs/earthsim/lib/libstdc++.so.6.0.24 /home/travis/miniconda/envs/earthsim/lib/libstdc++.so.6 
+        #- conda remove -y --force gcc
+        #- conda install -y --force -c conda-forge libgcc-ng scipy numpy libstdcxx-ng
         - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
         - doit capture_conda_env
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ jobs:
         - conda env create
         - source activate earthsim
         - doit develop_install
+        - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
+        - conda remove --force gcc
+        - conda install --force -c conda-forge libgcc-ng scipy numpy libstdcxx-ng
+        - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
         - doit capture_conda_env
       script:
         - doit download_sample_data

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ jobs:
         - source activate earthsim
         - doit develop_install
         - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
-        - conda remove --force gcc
-        - conda install --force -c conda-forge libgcc-ng scipy numpy libstdcxx-ng
+        - conda remove -y --force gcc
+        - conda install -y --force -c conda-forge libgcc-ng scipy numpy libstdcxx-ng
         - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
         - doit capture_conda_env
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ jobs:
         - conda env create
         - source activate earthsim
         - doit develop_install
-        - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
-        - rm -rf /home/travis/miniconda/envs/earthsim/lib/libstdc++.so.6
-        - ln -s /home/travis/miniconda/envs/earthsim/lib/libstdc++.so.6.0.24 /home/travis/miniconda/envs/earthsim/lib/libstdc++.so.6 
+        ###
+        # TODO: figure out what's depending on (deprecated?) gcc package; see https://github.com/pyviz/EarthSim/issues/97
+        - pushd /home/travis/miniconda/envs/earthsim/lib/ && rm -rf libstdc++.so.6 && ln -s libstdc++.so.6.0.24 libstdc++.so.6 && popd
         #- conda remove -y --force gcc
         #- conda install -y --force -c conda-forge libgcc-ng scipy numpy libstdcxx-ng
-        - ls -l /home/travis/miniconda/envs/earthsim/lib/libstdc++*
+        ###
         - doit capture_conda_env
       script:
         - doit download_sample_data


### PR DESCRIPTION
This seems to work locally for me, allowing filigree to work. Will try to figure out a better way to make this happen, so probably don't merge yet. As far as I know, nobody's being held up by filigree not working on linux (at least in this env).