### PR TITLE
Parameterized notebook examples

### DIFF
--- a/earthsim/__init__.py
+++ b/earthsim/__init__.py
@@ -39,7 +39,7 @@ def parameters(**kwargs):
     be used to parameterize a notebook, display corresponding widgets
     with parambokeh and control the workflow from the command line.
     """
-    name = 'Parameters'
+    name = kwargs.get('name', 'Parameters')
     params = params_from_kwargs(**kwargs)
     params['name'] = param.String(default=name)
     return type(name, (param.Parameterized,), params)

--- a/earthsim/__init__.py
+++ b/earthsim/__init__.py
@@ -32,14 +32,14 @@ def params_from_kwargs(**kwargs):
     return params
 
 
-def global_params(**kwargs):
+def parameters(**kwargs):
     """
     Utility to easily define a parameterized class with a chosen set of
     parameters specified as keyword arguments. The resulting object can
     be used to parameterize a notebook, display corresponding widgets
     with parambokeh and control the workflow from the command line.
     """
-    name = 'GlobalParams'
+    name = 'Parameters'
     params = params_from_kwargs(**kwargs)
     params['name'] = param.String(default=name)
     return type(name, (param.Parameterized,), params)

--- a/earthsim/__init__.py
+++ b/earthsim/__init__.py
@@ -1,0 +1,45 @@
+import param
+
+def params_from_kwargs(**kwargs):
+    """
+    Utility to promote keywords with literal values to the appropriate
+    parameter type with the specified default value unless the value is
+    already a parameter.
+    """
+    params = {}
+    for k, v in kwargs.items():
+        kws = dict(default=v)
+        if isinstance(v, param.Parameter):
+            params[k] = v
+        elif isinstance(v, bool):
+            params[k] = param.Boolean(**kws)
+        elif isinstance(v, int):
+            params[k] = param.Integer(**kws)
+        elif isinstance(v, float):
+            params[k] = param.Number(**kws)
+        elif isinstance(v, str):
+            params[k] = param.String(**kws)
+        elif isinstance(v, dict):
+            params[k] = param.Dict(**kws)
+        elif isinstance(v, tuple):
+            params[k] = param.Tuple(**kws)
+        elif isinstance(v, list):
+            params[k] = param.List(**kws)
+        elif isinstance(v, np.ndarray):
+            params[k] = param.Array(**kws)
+        else:
+            params[k] = param.Parameter(**kws)
+    return params
+
+
+def global_params(**kwargs):
+    """
+    Utility to easily define a parameterized class with a chosen set of
+    parameters specified as keyword arguments. The resulting object can
+    be used to parameterize a notebook, display corresponding widgets
+    with parambokeh and control the workflow from the command line.
+    """
+    name = 'GlobalParams'
+    params = params_from_kwargs(**kwargs)
+    params['name'] = param.String(default=name)
+    return type(name, (param.Parameterized,), params)

--- a/earthsim/__main__.py
+++ b/earthsim/__main__.py
@@ -1,0 +1,43 @@
+"""
+Prototype of a param script that can set global_params via the
+appropriate environment variable to execute an arbitrary command.
+
+Example usage:
+
+param -cmd 'jupyter nbconvert --execute GSSHA_Workflow_Batched_Example2.ipynb' -p rain_intensity=25 -p rain_duration=3600
+"""
+
+import os
+import sys
+import json
+import argparse
+import subprocess
+from distutils import spawn
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-cmd',type=str)
+    parser.add_argument("-p", nargs=1, action='append')
+    args = parser.parse_args()
+    if args.p is None:
+        print('Please supply parameters using the -p flag')
+        sys.exit(1)
+
+    if args.cmd is None:
+        print('Please supply a command string using the -cmd flag')
+        sys.exit(1)
+
+    execute(args)
+
+def execute(args):
+    split_strings = dict(el[0].split('=') for el in args.p)
+    json_dict = {k:eval(v) for k,v in split_strings.items()}
+    env = os.environ.copy() # Required on windows
+    env['PARAM_JSON_INIT'] = json.dumps(json_dict)
+    cmd = args.cmd.split()
+    p = subprocess.Popen(cmd, env=env,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+
+if __name__ == "__main__":
+    main()

--- a/earthsim/gssha/__init__.py
+++ b/earthsim/gssha/__init__.py
@@ -20,7 +20,7 @@ class Simulation(param.Parameterized):
 
     land_use_grid_id = param.Parameter(default='nlcd',precedence=0.3)
     
-    model_creator = param.ClassSelector(CreateModel,default=CreateGSSHAModel(),precedence=0.4)
+    model_creator = param.ClassSelector(CreateModel,default=CreateGSSHAModel(),precedence=-1)
 
     # TODO: switch to date range...
     simulation_start=param.Date(default=datetime(2017, 5 ,9),precedence=0.5)

--- a/earthsim/gssha/model.py
+++ b/earthsim/gssha/model.py
@@ -126,7 +126,7 @@ class CreateGSSHAModel(CreateModel):
     # created or else editing parameters on non-default options is
     # confusing.
     roughness = param.ClassSelector(RoughnessSpecification,default=UniformRoughness(),doc="""
-        Method for specifying roughness""") 
+        Method for specifying roughness""", precedence=-1) 
 
     out_hydrograph_write_frequency = param.Number(default=10, bounds=(1,60), doc="""
        Frequency of writing to hydrograph (minutes). Sets HYD_FREQ card. Required for new model.""", precedence=0.8)

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ channels:
     - defaults
 dependencies:
     - python>=3.5
+    - lancet
     - fiona
     - rasterio
     - gdal

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
@@ -27,13 +27,13 @@
     "\n",
     "```bash\n",
     "cd examples/topics/batched_example/\n",
-    "PARAM_JSON_INIT='{\"rain_intensity\":42, \"rain_duration\":50}' jupyter notebook GSSHA_Workflow_Batched_Example1.ipynb\n",
+    "PARAM_JSON_INIT='{\"rain_intensity\":42, \"rain_duration\":3600}' jupyter notebook GSSHA_Workflow_Batched_Example1.ipynb\n",
     "```\n",
     "\n",
     "You can also generate a report HTML file using ``nbconvert`` as follows:\n",
     "\n",
     "```bash\n",
-    "PARAM_JSON_INIT='{\"rain_intensity\":25, \"rain_duration\":60}' jupyter nbconvert --execute GSSHA_Workflow_Batched_Example1.ipynb --output report1.html\n",
+    "PARAM_JSON_INIT='{\"rain_intensity\":25, \"rain_duration\":3600}' jupyter nbconvert --execute GSSHA_Workflow_Batched_Example1.ipynb --output report1.html\n",
     "```\n",
     "\n",
     "This will set the ``rain_intensity`` and ``rain_duration`` values to ``42`` and ``50`` respectively from the default values of ``24`` and ``60``.\n",
@@ -109,7 +109,7 @@
     "    \n",
     "    rain_intensity= param.Number(default=24, bounds=(0,None), softbounds=(0,75))\n",
     "    \n",
-    "    rain_duration = param.Integer(default=60,bounds=(0,None), softbounds=(0,1000000))"
+    "    rain_duration = param.Integer(default=3600,bounds=(0,None), softbounds=(0,1000000))"
    ]
   },
   {

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
@@ -33,7 +33,7 @@
     "You can also generate a report HTML file using ``nbconvert`` as follows:\n",
     "\n",
     "```bash\n",
-    "PARAM_JSON_INIT='{\"rain_intensity\":25, \"rain_duration\":3600}' jupyter nbconvert --execute GSSHA_Workflow_Batched_Example1.ipynb --output report1.html\n",
+    "PARAM_JSON_INIT='{\"rain_intensity\":25, \"rain_duration\":3600}' jupyter nbconvert --execute GSSHA_Workflow_Batched_Example1.ipynb\n",
     "```\n",
     "\n",
     "This will set the ``rain_intensity`` and ``rain_duration`` values to ``42`` and ``50`` respectively from the default values of ``24`` and ``60``.\n",

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
@@ -38,9 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datetime import datetime, timedelta\n",
@@ -73,9 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rm -r ./vicksburg_south/"
@@ -98,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class NotebookParams(param.Parameterized):\n",
@@ -127,9 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "parambokeh.Widgets(NotebookParams, initializer=parambokeh.JSONInit())"
@@ -145,9 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model_creator = esgssha.CreateGSSHAModel(name='Vicksburg South Model Creator',\n",
@@ -166,9 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model_creator.roughness = UniformRoughness()\n",
@@ -192,9 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Polygons [width=900 height=500] (fill_alpha=0 line_color='black')\n",
@@ -211,9 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "if box_stream.element:\n",
@@ -245,9 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Shape [width=900 height=500 tools=['box_select']] (alpha=0.5)\n",
@@ -267,9 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Shape [width=600 height=400] (alpha=0.5)\n",
@@ -294,9 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim = esgssha.Simulation(name='Vicksburg South Simulation', simulation_duration=60*60,\n",
@@ -320,9 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim.rain_duration = NotebookParams.rain_duration \n",
@@ -332,9 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "parambokeh.Widgets(sim)"
@@ -352,9 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "if sim.model_creator.project_name not in quest.api.get_collections():\n",
@@ -364,9 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "parambokeh.Widgets(sim.model_creator)"
@@ -375,9 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# temporary workaround until workflow cleanup/parameterization is done\n",
@@ -396,9 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model = sim.model_creator()"
@@ -407,9 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# add card for max depth\n",
@@ -456,9 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "name = sim.model_creator.project_name\n",
@@ -483,9 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tiles * regrid(mask) * mask_shape"
@@ -501,9 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tiles * regrid(ele) * mask_shape"
@@ -519,9 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tiles * regrid(roughness) * mask_shape"
@@ -537,9 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from gsshapy.modeling import GSSHAFramework"
@@ -548,9 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# TODO: how does the info here relate to that set earlier?\n",
@@ -590,9 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "depth_nc = os.path.join(gssha_event_directory, 'depths.nc')\n",
@@ -631,9 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Image [width=600 height=400 logz=True xaxis=None yaxis=None] (cmap='viridis') Histogram {+framewise}\n",
@@ -650,9 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Image [width=300 height=300 logz=True xaxis=None yaxis=None] (cmap='viridis')\n",
@@ -671,9 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Image [width=600 height=400] (cmap='viridis')\n",
@@ -692,9 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Spikes [width=600]\n",
@@ -713,22 +655,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
@@ -1,0 +1,736 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Batched example 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is the first of a series that shows how [GSSHA_Workflow.ipynb](../GSSHA_Workflow.ipynb) can be parameterized at the command line. This parameterization is designed to enable parameter sweeps, automatic report generation and other new uses for notebooks.\n",
+    "\n",
+    "This first notebook aims to explain the basic mechanism used to parameterize notebooks. Although this is the least user friendly of the approaches, it also requires the fewest changes to EarthSim and the associated PyViz tools.\n",
+    "\n",
+    "The rest of the notebook is largely the same as [GSSHA_Workflow.ipynb](../GSSHA_Workflow.ipynb) although there are a few changes that are used to expose the notebook parameters at the command line. The two parameters we choose to expose are ``rain_intensity`` and ``rain_duration``.\n",
+    "\n",
+    "\n",
+    "1. <a href=\"#Declare_nbparams\">Declare the command line parameters</a>\n",
+    "2. <a href=\"#Display_nbparams\">Display the notebook parameter widgets</a>\n",
+    "3. <a href=\"#Apply_nbparams\">Apply notebook parameters and display</a>\n",
+    "\n",
+    "\n",
+    "Once the notebook is configured to use notebook parameters, they can be set at the command line as follows:\n",
+    "\n",
+    "```bash\n",
+    "cd examples/topics/batched_example/\n",
+    "PARAM_JSON_INIT='{\"rain_intensity\":42, \"rain_duration\":50}' jupyter notebook GSSHA_Workflow_Batched_Example1.ipynb\n",
+    "```\n",
+    "\n",
+    "This will set the ``rain_intensity`` and ``rain_duration`` values to ``42`` and ``50`` respectively from the default values of ``24`` and ``60``.\n",
+    "\n",
+    "The ``PARAM_JSON_INIT`` environment variable can be used this way to set the notebook parameters in other contexts (e.g using nbconvert to execute the notebook and save it out to HTML). In the next notebook, this approach for parameterizing notebooks is made more user friendly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timedelta\n",
+    "import os\n",
+    "import glob\n",
+    "\n",
+    "import param\n",
+    "import parambokeh\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import geoviews as gv\n",
+    "import holoviews as hv\n",
+    "import quest\n",
+    "import earthsim.gssha as esgssha\n",
+    "import earthsim.gssha.model as models\n",
+    "import cartopy.crs as ccrs\n",
+    "\n",
+    "from earthsim.gssha import download_data, get_file_from_quest\n",
+    "from earthsim.gssha.model import UniformRoughness, CreateGSSHAModel\n",
+    "from holoviews.streams import PolyEdit, BoxEdit, PointDraw, CDSStream\n",
+    "from holoviews.operation.datashader import regrid, shade\n",
+    "from earthsim.io import save_shapefile, open_gssha, get_ccrs\n",
+    "\n",
+    "regrid.aggregator = 'max'\n",
+    "\n",
+    "hv.extension('bokeh')\n",
+    "%output holomap='scrubber' fps=2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "rm -r ./vicksburg_south/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare the command line parameters <a id=\"Declare_nbparams\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this instance, the two chosen notebook parameters mirror those define on ``Simulation``. Mirroring parameters this way is optional and you can define any sensible notebook parameters that hook into the rest of the notebook workflow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "class NotebookParams(param.Parameterized):\n",
+    "    \n",
+    "    rain_intensity= param.Number(default=24, bounds=(0,None), softbounds=(0,75))\n",
+    "    \n",
+    "    rain_duration = param.Integer(default=60,bounds=(0,None), softbounds=(0,1000000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display the notebook parameter widgets  <a id=\"Display_nbparams\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This step makes the notebook parameters available to change at the start of the notebook, parameterizing the interactive workflow. In addition, using ``initializer=parambokeh.JSONInit()`` allows these parameters to be set from the command line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "parambokeh.Widgets(NotebookParams, initializer=parambokeh.JSONInit())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "model_creator = esgssha.CreateGSSHAModel(name='Vicksburg South Model Creator',\n",
+    "                                        mask_shapefile='../../data/vicksburg_watershed/watershed_boundary.shp',\n",
+    "                                        grid_cell_size=90)\n",
+    "parambokeh.Widgets(model_creator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting the parameters of the ``roughness`` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "model_creator.roughness = UniformRoughness()\n",
+    "parambokeh.Widgets(model_creator.roughness)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Draw bounds to compute watershed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Allows drawing a bounding box and adding points to serve as input to compute a watershed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Polygons [width=900 height=500] (fill_alpha=0 line_color='black')\n",
+    "%%opts Points (size=10 color='red')\n",
+    "tiles = gv.WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',\n",
+    "                crs=ccrs.PlateCarree(), extents=(-91, 32.2, -90.8, 32.4))\n",
+    "box_poly = hv.Polygons([])\n",
+    "points = hv.Points([])\n",
+    "box_stream = BoxEdit(source=box_poly)\n",
+    "point_stream = PointDraw(source=points)\n",
+    "tiles * box_poly * points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "if box_stream.element:\n",
+    "    element = gv.operation.project(box_stream.element, projection=ccrs.PlateCarree())\n",
+    "    xs, ys = element.array().T\n",
+    "    bounds = (xs[0], ys[1], xs[2], ys[0])\n",
+    "    print(\"BOUNDS\", bounds)\n",
+    "    \n",
+    "if point_stream.element:\n",
+    "    projected = gv.operation.project(point_stream.element, projection=ccrs.PlateCarree())\n",
+    "    print(\"COORDINATE:\", projected.iloc[0]['x'][0], projected.iloc[0]['y'][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect and edit shapefile\n",
+    "\n",
+    "The plot below allows editing the shapefile using a set of tools. The controls for editing are as follows:\n",
+    "    \n",
+    "* Double-clicking the polygon displays the vertices\n",
+    "* After double-clicking the point tool is selected and vertices can be dragged around\n",
+    "* By tapping on a vertex it can be selected, tapping in a new location while a single point is selected inserts a new vertex\n",
+    "* Multiple points can be selected by holding shift and then tapping or using the box_select tool\n",
+    "* Once multiple vertices are selected they can be deleted by selecting the point editing tool and pressing ``backspace``"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Shape [width=900 height=500 tools=['box_select']] (alpha=0.5)\n",
+    "mask_shape = gv.Shape.from_shapefile(model_creator.mask_shapefile).last\n",
+    "tiles = gv.WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png')\n",
+    "vertex_stream = PolyEdit(source=mask_shape)\n",
+    "tiles * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If any edits were made to the polygon in the plot above we save the ``watershed_boundary.shp`` back out and redisplay it to confirm our edits were applied correctly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Shape [width=600 height=400] (alpha=0.5)\n",
+    "if vertex_stream.data:\n",
+    "    edited_shape_fname = '../vicksburg_watershed_edited/watershed_boundary.shp'\n",
+    "    dir_name = os.path.dirname(edited_shape_fname)\n",
+    "    if not os.path.isdir(dir_name): os.makedirs(dir_name)\n",
+    "    save_shapefile(vertex_stream.data, edited_shape_fname, model_creator.mask_shapefile)\n",
+    "    model_creator.mask_shapefile = edited_shape_fname\n",
+    "    mask_shape = gv.Shape.from_shapefile(edited_shape_fname).last\n",
+    "mask_shape = mask_shape.opts() # Clear options\n",
+    "mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure simulation parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "sim = esgssha.Simulation(name='Vicksburg South Simulation', simulation_duration=60*60,\n",
+    "                          rain_duration=30*60, model_creator=model_creator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Apply notebook parameters and display<a id=\"Apply_nbparams\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the point at which the notebook parameters hook into the workflow. In this example, the two chosen parameters ``rain_duration`` and ``rain_intensity`` are simply set on ``sim``. In more complex examples, you may decide to compute the parameters set in the workflow as a function of the availabel notebook parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "sim.rain_duration = NotebookParams.rain_duration \n",
+    "sim.rain_intensity = NotebookParams.rain_intensity "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "parambokeh.Widgets(sim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the model\n",
+    "\n",
+    "Note that the above code demonstrates how to collect user input, but it has not yet been connected to the remaining workflow, which uses code-based specification for the parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "if sim.model_creator.project_name not in quest.api.get_collections():\n",
+    "    quest.api.new_collection(sim.model_creator.project_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "parambokeh.Widgets(sim.model_creator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# temporary workaround until workflow cleanup/parameterization is done\n",
+    "if sim.model_creator.project_name == 'test_philippines_small':\n",
+    "    sim.model_creator.roughness = models.GriddedRoughnessTable(\n",
+    "        land_use_grid=get_file_from_quest(sim.model_creator.project_name, sim.land_use_service, 'landuse', sim.model_creator.mask_shapefile),\n",
+    "        land_use_to_roughness_table='../philippines_small/land_cover_glcf_modis.txt')\n",
+    "else:    \n",
+    "    sim.model_creator.roughness = models.GriddedRoughnessID(\n",
+    "        land_use_grid=get_file_from_quest(sim.model_creator.project_name, sim.land_use_service, 'landuse', sim.model_creator.mask_shapefile),\n",
+    "        land_use_grid_id=sim.land_use_grid_id)\n",
+    "\n",
+    "sim.model_creator.elevation_grid_path = get_file_from_quest(sim.model_creator.project_name, sim.elevation_service, 'elevation', sim.model_creator.mask_shapefile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "model = sim.model_creator()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# add card for max depth\n",
+    "model.project_manager.setCard('FLOOD_GRID',\n",
+    "                              '{0}.fgd'.format(sim.model_creator.project_name),\n",
+    "                              add_quotes=True)\n",
+    "# Add time-based depth grids to simulation\n",
+    "\"\"\"\n",
+    "See: http://www.gsshawiki.com/Project_File:Output_Files_%E2%80%93_Required\n",
+    "\n",
+    "Filename or folder to output MAP_TYPE maps of overland flow depth (m) \n",
+    "every MAP_FREQ minutes. If MAP_TYPE=0, then [value] is a folder name \n",
+    "and output files are called \"value\\depth.####.asc\" **\n",
+    "\"\"\"\n",
+    "\n",
+    "model.project_manager.setCard('DEPTH', '.', add_quotes=True)\n",
+    "model.project_manager.setCard('MAP_FREQ', '1')\n",
+    "\n",
+    "# add event for simulation (optional)\n",
+    "\"\"\"\n",
+    "model.set_event(simulation_start=sim.simulation_start,\n",
+    "                simulation_duration=timedelta(seconds=sim.simulation_duration),\n",
+    "                rain_intensity=sim.rain_intensity,\n",
+    "                rain_duration=timedelta(seconds=sim.rain_duration))\n",
+    "\"\"\"\n",
+    "# write to disk\n",
+    "model.write()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Review model inputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load inputs to the simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "name = sim.model_creator.project_name\n",
+    "CRS = get_ccrs(os.path.join(name, name+'_prj.pro'))\n",
+    "\n",
+    "roughness_arr = open_gssha(os.path.join(name,'roughness.idx'))\n",
+    "msk_arr = open_gssha(os.path.join(name, name+'.msk'))\n",
+    "ele_arr = open_gssha(os.path.join(name, name+'.ele'))\n",
+    "\n",
+    "roughness = gv.Image(roughness_arr, crs=CRS, label='roughness.idx')\n",
+    "mask = gv.Image(msk_arr, crs=CRS, label='vicksburg_south.msk')\n",
+    "ele  = gv.Image(ele_arr, crs=CRS, label='vicksburg_south.ele')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Shapefile vs. Mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "tiles * regrid(mask) * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Elevation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "tiles * regrid(ele) * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Roughness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "tiles * regrid(roughness) * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from gsshapy.modeling import GSSHAFramework"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# TODO: how does the info here relate to that set earlier?\n",
+    "\n",
+    "# TODO: understand comment below\n",
+    "# assuming notebook is run from examples folder\n",
+    "project_path = os.path.join(sim.model_creator.project_base_directory, sim.model_creator.project_name)\n",
+    "gr = GSSHAFramework(\"gssha\",\n",
+    "                    project_path,\n",
+    "                    \"{0}.prj\".format(sim.model_creator.project_name),\n",
+    "                    gssha_simulation_start=sim.simulation_start,\n",
+    "                    gssha_simulation_duration=timedelta(seconds=sim.simulation_duration),\n",
+    "                    # load_simulation_datetime=True,  # use this if already set datetime params in project file\n",
+    "                   )\n",
+    "\n",
+    "# http://www.gsshawiki.com/Model_Construction:Defining_a_uniform_precipitation_event\n",
+    "gr.event_manager.add_uniform_precip_event(sim.rain_intensity, \n",
+    "                                          timedelta(seconds=sim.rain_duration))\n",
+    "\n",
+    "gssha_event_directory = gr.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load and visualize depths over time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "depth_nc = os.path.join(gssha_event_directory, 'depths.nc')\n",
+    "if not os.path.isfile(depth_nc):\n",
+    "    # Load depth data files\n",
+    "    depth_map = hv.HoloMap(kdims=['Minute'])\n",
+    "    for fname in glob.glob(os.path.join(gssha_event_directory, 'depth.*.asc')):\n",
+    "        depth_arr = open_gssha(fname)\n",
+    "        minute = int(fname.split('.')[-2])\n",
+    "        # NOTE: Due to precision issues not all empty cells match the NaN value properly, fix later\n",
+    "        depth_arr.data[depth_arr.data==depth_arr.data[0,0]] = np.NaN\n",
+    "        depth_map[minute] = hv.Image(depth_arr)\n",
+    "\n",
+    "    # Convert data to an xarray and save as NetCDF\n",
+    "    arrays = []\n",
+    "    for minute, img in depth_map.items():\n",
+    "        ds = hv.Dataset(img)\n",
+    "        arr = ds.data.z.assign_coords(minute=minute)\n",
+    "        arrays.append(arr)\n",
+    "    depths = xr.concat(arrays, 'minute')\n",
+    "    depths.to_netcdf(depth_nc)\n",
+    "else:\n",
+    "    depths = xr.open_dataset(depth_nc)\n",
+    "\n",
+    "depth_ds = hv.Dataset(depths)\n",
+    "depth_ds.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have a Dataset of depths we can convert it to a series of Images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=600 height=400 logz=True xaxis=None yaxis=None] (cmap='viridis') Histogram {+framewise}\n",
+    "regrid(depth_ds.to(hv.Image, ['x', 'y'])).redim.range(z=(0, 0.04)).hist(bin_range=(0, 0.04))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also lay out the plots over time to allow for easier comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=300 height=300 logz=True xaxis=None yaxis=None] (cmap='viridis')\n",
+    "regrid(depth_ds.select(minute=range(10, 70, 10)).to(hv.Image, ['x', 'y']).redim.range(z=(0, 0.04))).layout().cols(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flood Grid Depth\n",
+    "\n",
+    "(Maximum flood depth over the course of the simulation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=600 height=400] (cmap='viridis')\n",
+    "fgd_arr = open_gssha(os.path.join(gssha_event_directory,'{0}.fgd'.format(sim.model_creator.project_name)))\n",
+    "fgd = gv.Image(fgd_arr, crs=CRS, label='vicksburg_south.fgd').redim.range(z=(0, 0.04))\n",
+    "regrid(fgd, streams=[hv.streams.RangeXY]).redim.range(z=(0, 0.04))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Analyzing the simulation speed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Spikes [width=600]\n",
+    "times = np.array([os.path.getmtime(f) for f in glob.glob(os.path.join(gssha_event_directory, 'depth*.asc'))] )\n",
+    "minutes = (times-times[0])/60\n",
+    "hv.Spikes(minutes, kdims=['Real Time (minutes)'], label='Time elapsed for each minute of simulation time') +\\\n",
+    "hv.Curve(np.diff(minutes), kdims=['Simulation Time (min)'], vdims=[('runtime', 'Runtime per minute simulation time')]).redim.range(runtime=(0, None))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here if the \"spikes\" are regularly spaced, simulation time is regularly scaled with real time, and so you should be able read out the approximate time to expect per unit of simulation time."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example1.ipynb
@@ -30,9 +30,17 @@
     "PARAM_JSON_INIT='{\"rain_intensity\":42, \"rain_duration\":50}' jupyter notebook GSSHA_Workflow_Batched_Example1.ipynb\n",
     "```\n",
     "\n",
+    "You can also generate a report HTML file using ``nbconvert`` as follows:\n",
+    "\n",
+    "```bash\n",
+    "PARAM_JSON_INIT='{\"rain_intensity\":25, \"rain_duration\":60}' jupyter nbconvert --execute GSSHA_Workflow_Batched_Example1.ipynb --output report1.html\n",
+    "```\n",
+    "\n",
     "This will set the ``rain_intensity`` and ``rain_duration`` values to ``42`` and ``50`` respectively from the default values of ``24`` and ``60``.\n",
     "\n",
-    "The ``PARAM_JSON_INIT`` environment variable can be used this way to set the notebook parameters in other contexts (e.g using nbconvert to execute the notebook and save it out to HTML). In the next notebook, this approach for parameterizing notebooks is made more user friendly."
+    "The ``PARAM_JSON_INIT`` variable can be used this way to set the notebook parameters in any context where the environment variables are available in the execution context of the notebook. One major limitation of this approach is that setting environment variables on Windows requires a different syntax.\n",
+    "\n",
+    "In the next notebook, this approach for parameterizing notebooks is made more user friendly and generalized to work on Windows."
    ]
   },
   {

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
@@ -19,7 +19,7 @@
     "2. <a href=\"#Display_nbparams\">Display the notebook parameter widgets</a>\n",
     "3. <a href=\"#Apply_nbparams\">Apply notebook parameters and display</a>\n",
     "\n",
-    "Only the first step <a href=\"#Declare_nbparams\">Declare the command line parameters</a> is different from the first example, the second step is identical and the third step is only different by a trivial variable name change.\n",
+    "Only the first step <a href=\"#Declare_nbparams\">Declare the command line parameters</a> is different from the first example; the second step is identical and the third step is only different by a trivial variable name change.\n",
     "\n",
     "The main improvement presented here is in the interface used to set parameters at the command line:\n",
     "\n",
@@ -105,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the literal specification can be easier to read but documentation and numeric bounds declarations. This may also result in less user-friendly widgets:  ``rain_duration`` is displayed with a text box in the next code cell instead of a slider. Using literals to define notebook parameters is most appropriate for generating static HTML reports from the command line where the widgets won't be used."
+    "Note that the literal specification is shorter and easier to read but is lacking documentation and numeric bounds declarations. This may also result in less user-friendly widgets:  ``rain_duration`` is displayed with a text box in the next code cell instead of a slider. Using literals to define notebook parameters is most appropriate for generating static HTML reports from the command line where the widgets won't be used."
    ]
   },
   {

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
@@ -22,7 +22,12 @@
     "Only the first step <a href=\"#Declare_nbparams\">Declare the command line parameters</a> is different from the first example, the second step is identical and the third step is only different by a trivial variable name change.\n",
     "\n",
     "The main improvement presented here is in the interface used to set parameters at the command line:\n",
-    "\n"
+    "\n",
+    "```bash\n",
+    "param -cmd 'jupyter nbconvert --execute GSSHA_Workflow_Batched_Example2.ipynb' -p rain_intensity=25 -p rain_duration=3600\n",
+    "```\n",
+    "\n",
+    "As in the first example, an arbitrary command can be executed but in this instance a nicer syntax is used to specify the desired parameters. The ``param`` command generates the appropriate environment variable and makes it available to the execution context in a way that is cross platform, allowing this utility to be used on Windows."
    ]
   },
   {

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
@@ -1,0 +1,664 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Batched example 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is the second of a series that shows how [GSSHA_Workflow.ipynb](../GSSHA_Workflow.ipynb) can be parameterized at the command line that builds on [GSSHA_Workflow_Batched_Example1](GSSHA_Workflow_Batched_Example1.ipynb). This notebook uses the same principles as the first example but makes the interface more user friendly and Windows compatible.\n",
+    "\n",
+    "As in the first example, the two parameters we choose to expose are ``rain_intensity`` and ``rain_duration``. As before, the notebook is configured to use these parameters in three steps.\n",
+    "\n",
+    "1. <a href=\"#Declare_nbparams\">Declare the command line parameters</a>\n",
+    "2. <a href=\"#Display_nbparams\">Display the notebook parameter widgets</a>\n",
+    "3. <a href=\"#Apply_nbparams\">Apply notebook parameters and display</a>\n",
+    "\n",
+    "Only the first step <a href=\"#Declare_nbparams\">Declare the command line parameters</a> is different from the first example, the second step is identical and the third step is only different by a trivial variable name change.\n",
+    "\n",
+    "The main improvement presented here is in the interface used to set parameters at the command line:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timedelta\n",
+    "import os\n",
+    "import glob\n",
+    "\n",
+    "import param\n",
+    "import parambokeh\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import geoviews as gv\n",
+    "import holoviews as hv\n",
+    "import quest\n",
+    "import earthsim.gssha as esgssha\n",
+    "import earthsim.gssha.model as models\n",
+    "import cartopy.crs as ccrs\n",
+    "\n",
+    "from earthsim.gssha import download_data, get_file_from_quest\n",
+    "from earthsim.gssha.model import UniformRoughness, CreateGSSHAModel\n",
+    "from holoviews.streams import PolyEdit, BoxEdit, PointDraw, CDSStream\n",
+    "from holoviews.operation.datashader import regrid, shade\n",
+    "from earthsim.io import save_shapefile, open_gssha, get_ccrs\n",
+    "\n",
+    "regrid.aggregator = 'max'\n",
+    "\n",
+    "hv.extension('bokeh')\n",
+    "%output holomap='scrubber' fps=2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rm -r ./vicksburg_south/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare the command line parameters <a id=\"Declare_nbparams\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in the previous example, the  ``rain_intensity`` and ``rain_duration`` of ``Simulation`` are exposed. The change here is that instead of explicitly defining the ``NotebookParams`` class, a helper function called ``global_params`` is used instead.\n",
+    "\n",
+    "This utility makes the definition of notebook parameters more concise and readable. In addition to parameter objects, you can simply use literals for quick parameter definitions. For instance, the literal ``5`` is promoted to a ``param.Integer``, the literal ``6.2`` is promoted to a ``param.Number``, ``'example'`` is promoted to a ``param.String`` etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from earthsim import global_params\n",
+    "nbparams = global_params(\n",
+    "    rain_intensity = param.Number(default=24, bounds=(0,None), softbounds=(0,75)),\n",
+    "    rain_duration = 60\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the literal specification can be easier to read but documentation and numeric bounds declarations. This may also result in less user-friendly widgets:  ``rain_duration`` is displayed with a text box in the next code cell instead of a slider. Using literals to define notebook parameters is most appropriate for generating static HTML reports from the command line where the widgets won't be used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display the notebook parameter widgets  <a id=\"Display_nbparams\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This step makes the notebook parameters available to change at the start of the notebook, parameterizing the interactive workflow. In addition, using ``initializer=parambokeh.JSONInit()`` allows these parameters to be set from the command line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parambokeh.Widgets(nbparams, initializer=parambokeh.JSONInit())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_creator = esgssha.CreateGSSHAModel(name='Vicksburg South Model Creator',\n",
+    "                                        mask_shapefile='../../data/vicksburg_watershed/watershed_boundary.shp',\n",
+    "                                        grid_cell_size=90)\n",
+    "parambokeh.Widgets(model_creator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting the parameters of the ``roughness`` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_creator.roughness = UniformRoughness()\n",
+    "parambokeh.Widgets(model_creator.roughness)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Draw bounds to compute watershed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Allows drawing a bounding box and adding points to serve as input to compute a watershed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Polygons [width=900 height=500] (fill_alpha=0 line_color='black')\n",
+    "%%opts Points (size=10 color='red')\n",
+    "tiles = gv.WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',\n",
+    "                crs=ccrs.PlateCarree(), extents=(-91, 32.2, -90.8, 32.4))\n",
+    "box_poly = hv.Polygons([])\n",
+    "points = hv.Points([])\n",
+    "box_stream = BoxEdit(source=box_poly)\n",
+    "point_stream = PointDraw(source=points)\n",
+    "tiles * box_poly * points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if box_stream.element:\n",
+    "    element = gv.operation.project(box_stream.element, projection=ccrs.PlateCarree())\n",
+    "    xs, ys = element.array().T\n",
+    "    bounds = (xs[0], ys[1], xs[2], ys[0])\n",
+    "    print(\"BOUNDS\", bounds)\n",
+    "    \n",
+    "if point_stream.element:\n",
+    "    projected = gv.operation.project(point_stream.element, projection=ccrs.PlateCarree())\n",
+    "    print(\"COORDINATE:\", projected.iloc[0]['x'][0], projected.iloc[0]['y'][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect and edit shapefile\n",
+    "\n",
+    "The plot below allows editing the shapefile using a set of tools. The controls for editing are as follows:\n",
+    "    \n",
+    "* Double-clicking the polygon displays the vertices\n",
+    "* After double-clicking the point tool is selected and vertices can be dragged around\n",
+    "* By tapping on a vertex it can be selected, tapping in a new location while a single point is selected inserts a new vertex\n",
+    "* Multiple points can be selected by holding shift and then tapping or using the box_select tool\n",
+    "* Once multiple vertices are selected they can be deleted by selecting the point editing tool and pressing ``backspace``"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Shape [width=900 height=500 tools=['box_select']] (alpha=0.5)\n",
+    "mask_shape = gv.Shape.from_shapefile(model_creator.mask_shapefile).last\n",
+    "tiles = gv.WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png')\n",
+    "vertex_stream = PolyEdit(source=mask_shape)\n",
+    "tiles * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If any edits were made to the polygon in the plot above we save the ``watershed_boundary.shp`` back out and redisplay it to confirm our edits were applied correctly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Shape [width=600 height=400] (alpha=0.5)\n",
+    "if vertex_stream.data:\n",
+    "    edited_shape_fname = '../vicksburg_watershed_edited/watershed_boundary.shp'\n",
+    "    dir_name = os.path.dirname(edited_shape_fname)\n",
+    "    if not os.path.isdir(dir_name): os.makedirs(dir_name)\n",
+    "    save_shapefile(vertex_stream.data, edited_shape_fname, model_creator.mask_shapefile)\n",
+    "    model_creator.mask_shapefile = edited_shape_fname\n",
+    "    mask_shape = gv.Shape.from_shapefile(edited_shape_fname).last\n",
+    "mask_shape = mask_shape.opts() # Clear options\n",
+    "mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure simulation parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = esgssha.Simulation(name='Vicksburg South Simulation', simulation_duration=60*60,\n",
+    "                          rain_duration=30*60, model_creator=model_creator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Apply notebook parameters and display<a id=\"Apply_nbparams\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the point at which the notebook parameters hook into the workflow. In this example, the two chosen parameters ``rain_duration`` and ``rain_intensity`` are simply set on ``sim``. In more complex examples, you may decide to compute the parameters set in the workflow as a function of the availabel notebook parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.rain_duration = nbparams.rain_duration \n",
+    "sim.rain_intensity = nbparams.rain_intensity "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parambokeh.Widgets(sim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the model\n",
+    "\n",
+    "Note that the above code demonstrates how to collect user input, but it has not yet been connected to the remaining workflow, which uses code-based specification for the parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sim.model_creator.project_name not in quest.api.get_collections():\n",
+    "    quest.api.new_collection(sim.model_creator.project_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parambokeh.Widgets(sim.model_creator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# temporary workaround until workflow cleanup/parameterization is done\n",
+    "if sim.model_creator.project_name == 'test_philippines_small':\n",
+    "    sim.model_creator.roughness = models.GriddedRoughnessTable(\n",
+    "        land_use_grid=get_file_from_quest(sim.model_creator.project_name, sim.land_use_service, 'landuse', sim.model_creator.mask_shapefile),\n",
+    "        land_use_to_roughness_table='../philippines_small/land_cover_glcf_modis.txt')\n",
+    "else:    \n",
+    "    sim.model_creator.roughness = models.GriddedRoughnessID(\n",
+    "        land_use_grid=get_file_from_quest(sim.model_creator.project_name, sim.land_use_service, 'landuse', sim.model_creator.mask_shapefile),\n",
+    "        land_use_grid_id=sim.land_use_grid_id)\n",
+    "\n",
+    "sim.model_creator.elevation_grid_path = get_file_from_quest(sim.model_creator.project_name, sim.elevation_service, 'elevation', sim.model_creator.mask_shapefile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = sim.model_creator()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add card for max depth\n",
+    "model.project_manager.setCard('FLOOD_GRID',\n",
+    "                              '{0}.fgd'.format(sim.model_creator.project_name),\n",
+    "                              add_quotes=True)\n",
+    "# Add time-based depth grids to simulation\n",
+    "\"\"\"\n",
+    "See: http://www.gsshawiki.com/Project_File:Output_Files_%E2%80%93_Required\n",
+    "\n",
+    "Filename or folder to output MAP_TYPE maps of overland flow depth (m) \n",
+    "every MAP_FREQ minutes. If MAP_TYPE=0, then [value] is a folder name \n",
+    "and output files are called \"value\\depth.####.asc\" **\n",
+    "\"\"\"\n",
+    "\n",
+    "model.project_manager.setCard('DEPTH', '.', add_quotes=True)\n",
+    "model.project_manager.setCard('MAP_FREQ', '1')\n",
+    "\n",
+    "# add event for simulation (optional)\n",
+    "\"\"\"\n",
+    "model.set_event(simulation_start=sim.simulation_start,\n",
+    "                simulation_duration=timedelta(seconds=sim.simulation_duration),\n",
+    "                rain_intensity=sim.rain_intensity,\n",
+    "                rain_duration=timedelta(seconds=sim.rain_duration))\n",
+    "\"\"\"\n",
+    "# write to disk\n",
+    "model.write()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Review model inputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load inputs to the simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = sim.model_creator.project_name\n",
+    "CRS = get_ccrs(os.path.join(name, name+'_prj.pro'))\n",
+    "\n",
+    "roughness_arr = open_gssha(os.path.join(name,'roughness.idx'))\n",
+    "msk_arr = open_gssha(os.path.join(name, name+'.msk'))\n",
+    "ele_arr = open_gssha(os.path.join(name, name+'.ele'))\n",
+    "\n",
+    "roughness = gv.Image(roughness_arr, crs=CRS, label='roughness.idx')\n",
+    "mask = gv.Image(msk_arr, crs=CRS, label='vicksburg_south.msk')\n",
+    "ele  = gv.Image(ele_arr, crs=CRS, label='vicksburg_south.ele')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Shapefile vs. Mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tiles * regrid(mask) * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Elevation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tiles * regrid(ele) * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Roughness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tiles * regrid(roughness) * mask_shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gsshapy.modeling import GSSHAFramework"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: how does the info here relate to that set earlier?\n",
+    "\n",
+    "# TODO: understand comment below\n",
+    "# assuming notebook is run from examples folder\n",
+    "project_path = os.path.join(sim.model_creator.project_base_directory, sim.model_creator.project_name)\n",
+    "gr = GSSHAFramework(\"gssha\",\n",
+    "                    project_path,\n",
+    "                    \"{0}.prj\".format(sim.model_creator.project_name),\n",
+    "                    gssha_simulation_start=sim.simulation_start,\n",
+    "                    gssha_simulation_duration=timedelta(seconds=sim.simulation_duration),\n",
+    "                    # load_simulation_datetime=True,  # use this if already set datetime params in project file\n",
+    "                   )\n",
+    "\n",
+    "# http://www.gsshawiki.com/Model_Construction:Defining_a_uniform_precipitation_event\n",
+    "gr.event_manager.add_uniform_precip_event(sim.rain_intensity, \n",
+    "                                          timedelta(seconds=sim.rain_duration))\n",
+    "\n",
+    "gssha_event_directory = gr.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load and visualize depths over time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "depth_nc = os.path.join(gssha_event_directory, 'depths.nc')\n",
+    "if not os.path.isfile(depth_nc):\n",
+    "    # Load depth data files\n",
+    "    depth_map = hv.HoloMap(kdims=['Minute'])\n",
+    "    for fname in glob.glob(os.path.join(gssha_event_directory, 'depth.*.asc')):\n",
+    "        depth_arr = open_gssha(fname)\n",
+    "        minute = int(fname.split('.')[-2])\n",
+    "        # NOTE: Due to precision issues not all empty cells match the NaN value properly, fix later\n",
+    "        depth_arr.data[depth_arr.data==depth_arr.data[0,0]] = np.NaN\n",
+    "        depth_map[minute] = hv.Image(depth_arr)\n",
+    "\n",
+    "    # Convert data to an xarray and save as NetCDF\n",
+    "    arrays = []\n",
+    "    for minute, img in depth_map.items():\n",
+    "        ds = hv.Dataset(img)\n",
+    "        arr = ds.data.z.assign_coords(minute=minute)\n",
+    "        arrays.append(arr)\n",
+    "    depths = xr.concat(arrays, 'minute')\n",
+    "    depths.to_netcdf(depth_nc)\n",
+    "else:\n",
+    "    depths = xr.open_dataset(depth_nc)\n",
+    "\n",
+    "depth_ds = hv.Dataset(depths)\n",
+    "depth_ds.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have a Dataset of depths we can convert it to a series of Images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=600 height=400 logz=True xaxis=None yaxis=None] (cmap='viridis') Histogram {+framewise}\n",
+    "regrid(depth_ds.to(hv.Image, ['x', 'y'])).redim.range(z=(0, 0.04)).hist(bin_range=(0, 0.04))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also lay out the plots over time to allow for easier comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=300 height=300 logz=True xaxis=None yaxis=None] (cmap='viridis')\n",
+    "regrid(depth_ds.select(minute=range(10, 70, 10)).to(hv.Image, ['x', 'y']).redim.range(z=(0, 0.04))).layout().cols(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flood Grid Depth\n",
+    "\n",
+    "(Maximum flood depth over the course of the simulation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=600 height=400] (cmap='viridis')\n",
+    "fgd_arr = open_gssha(os.path.join(gssha_event_directory,'{0}.fgd'.format(sim.model_creator.project_name)))\n",
+    "fgd = gv.Image(fgd_arr, crs=CRS, label='vicksburg_south.fgd').redim.range(z=(0, 0.04))\n",
+    "regrid(fgd, streams=[hv.streams.RangeXY]).redim.range(z=(0, 0.04))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Analyzing the simulation speed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Spikes [width=600]\n",
+    "times = np.array([os.path.getmtime(f) for f in glob.glob(os.path.join(gssha_event_directory, 'depth*.asc'))] )\n",
+    "minutes = (times-times[0])/60\n",
+    "hv.Spikes(minutes, kdims=['Real Time (minutes)'], label='Time elapsed for each minute of simulation time') +\\\n",
+    "hv.Curve(np.diff(minutes), kdims=['Simulation Time (min)'], vdims=[('runtime', 'Runtime per minute simulation time')]).redim.range(runtime=(0, None))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here if the \"spikes\" are regularly spaced, simulation time is regularly scaled with real time, and so you should be able read out the approximate time to expect per unit of simulation time."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
+++ b/examples/topics/batched_example/GSSHA_Workflow_Batched_Example2.ipynb
@@ -94,8 +94,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from earthsim import global_params\n",
-    "nbparams = global_params(\n",
+    "from earthsim import parameters\n",
+    "nbparams = parameters(\n",
     "    rain_intensity = param.Number(default=24, bounds=(0,None), softbounds=(0,75)),\n",
     "    rain_duration = 60\n",
     ")"

--- a/examples/topics/batched_example/Rain_Intensity_Sweep_Example.ipynb
+++ b/examples/topics/batched_example/Rain_Intensity_Sweep_Example.ipynb
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the result of calling it's ``show`` method used to inspect the sets of arguments that will be executed:"
+    "And the result of calling its ``show`` method used to inspect the sets of arguments that will be executed:"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "source": [
     "Next we need to define how our arguments map to the ``param`` command described in [GSSHA_Workflow_Batched_Example2](GSSHA_Workflow_Batched_Example2.ipynb). To do this we define a ``ReportCommand`` subclass of ``lancet.Command``.\n",
     "\n",
-    "Note that this code is shown in this notebook to demonstrate how easy it is to interface lancet with an arbitrary command. Normally you would not show this code in a notebook and would simply import ``ReportCommand`` from the appropriate library."
+    "Note that this code is shown in this notebook to demonstrate how to interface lancet with an arbitrary command. Normally you would not show this code in a notebook and would simply import ``ReportCommand`` from the appropriate library."
    ]
   },
   {
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we instantiate ``ReportCommand`` by specifying the path to the notebook we want to use to generate reports. We then look at this objects ``repr``:"
+    "Now we instantiate ``ReportCommand`` by specifying the path to the notebook we want to use to generate reports. We then look at this object's ``repr``:"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "source": [
     "Lastly, we declare a ``lancet.Launcher`` instance and call it to execute the batches locally. To run this on an Oracle Grid Engine cluster you should simply replace ``lancet.Launcher`` with ``lancet.QLauncher``.\n",
     "\n",
-    "A ``Launcher`` takes a name for the experimental run, the ``Args`` and ``Command`` objects and optional arguments such as the directory to collect results in (here it is ``'output'``) and a chosen limit on the number of concurrent process executed:"
+    "A ``Launcher`` takes a name for the experimental run, the ``Args`` and ``Command`` objects, and optional arguments such as the directory to collect results in (here it is ``'output'``) and a chosen limit on the number of concurrent processes executed:"
    ]
   },
   {
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This command will take a few minutes to execute, blocking the notebook thread as the batches are being run locally. If ``QLauncher`` were used or another ``Launcher`` based on an HPC batch system, this would return as soon as the jobs are queued."
+    "This command will take a few minutes to execute, blocking the notebook thread as the batches are being run locally. If ``QLauncher`` were used or another ``Launcher`` based on an HPC batch system, this command would return as soon as the jobs are queued."
    ]
   },
   {

--- a/examples/topics/batched_example/Rain_Intensity_Sweep_Example.ipynb
+++ b/examples/topics/batched_example/Rain_Intensity_Sweep_Example.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook, we will use [Lancet](https://ioam.github.io/lancet/) to perform a parameter sweep over 3 values of the ``rain_intensity`` parameter defined in [GSSHA_Workflow_Batched_Example2](GSSHA_Workflow_Batched_Example2.ipynb).\n",
+    "\n",
+    "First import lancet:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lancet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declaring the ``Arguments``\n",
+    "\n",
+    "Next we define our constant parameters using ``lancet.Args``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rain_duration = lancet.Args(rain_duration=3600)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we use ``lancet.List`` to define the three parameters we want to use for ``rain_intensity``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rain_intensity       = lancet.List('rain_intensity', [24,26,28])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we take the cartesian product of these parameters using the ``*`` operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args = rain_intensity * rain_duration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is the ``args`` object's repr:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the result of calling it's ``show`` method used to inspect the sets of arguments that will be executed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining ``ReportCommand``"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we need to define how our arguments map to the ``param`` command described in [GSSHA_Workflow_Batched_Example2](GSSHA_Workflow_Batched_Example2.ipynb). To do this we define a ``ReportCommand`` subclass of ``lancet.Command``.\n",
+    "\n",
+    "Note that this code is shown in this notebook to demonstrate how easy it is to interface lancet with an arbitrary command. Normally you would not show this code in a notebook and would simply import ``ReportCommand`` from the appropriate library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import param\n",
+    "import os\n",
+    "class ReportCommand(lancet.Command):\n",
+    "    \n",
+    "    notebook_path = param.String(doc='Path to the notebook used to generate the report')\n",
+    "    \n",
+    "    options = param.List(['--ExecutePreprocessor.allow_errors=True', \n",
+    "                          '--ExecutePreprocessor.timeout=900'], doc=\"\"\"\n",
+    "    Additional options to supply to nbconvert.\"\"\")\n",
+    "\n",
+    "    def __init__(self, notebook_path, **params):\n",
+    "        super(ReportCommand,self).__init__(notebook_path=notebook_path,\n",
+    "                                          do_format=False,\n",
+    "                                          **params)\n",
+    "        self.pprint_args(['notebook_path'],['options'])\n",
+    "        \n",
+    "    def _fname(self, spec, tid, info):\n",
+    "        excluding = []\n",
+    "        root_dir = info['root_directory']\n",
+    "        params = [('tid' , tid)] + [(k,v) for  (k,v) in spec.items()\n",
+    "                                    if k in info['varying_keys']\n",
+    "                                    and k not in excluding]\n",
+    "        basename = '_'.join('%s=%s' % (k,v) for (k,v) in sorted(params))\n",
+    "        return os.path.join(root_dir, '%s_%s' % (info['batch_name'],\n",
+    "                                                   basename))\n",
+    "    def __call__(self, spec, tid=None, info={}):\n",
+    "        keywords = ['%s=%r' % (k,v) for k,v in spec.items()]\n",
+    "        params = []\n",
+    "        for kw in keywords:\n",
+    "            params.append('-p')\n",
+    "            params.append(kw)\n",
+    "            \n",
+    "        output_options = \"--output-dir=%s --output %s\" % (info['root_directory'], \n",
+    "                                                          self._fname(spec, tid, info))\n",
+    "        inner_cmd = \"jupyter nbconvert --execute %s %s %s\" % (self.notebook_path, \n",
+    "                                                              ' '.join(self.options),\n",
+    "                                                              output_options)\n",
+    "        return ['param', '-cmd', inner_cmd] + params\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiating ``ReportCommand``"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we instantiate ``ReportCommand`` by specifying the path to the notebook we want to use to generate reports. We then look at this objects ``repr``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "notebook_path = os.path.abspath('GSSHA_Workflow_Batched_Example2.ipynb')\n",
+    "gssha_report = ReportCommand(notebook_path=notebook_path)\n",
+    "gssha_report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running the batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, we declare a ``lancet.Launcher`` instance and call it to execute the batches locally. To run this on an Oracle Grid Engine cluster you should simply replace ``lancet.Launcher`` with ``lancet.QLauncher``.\n",
+    "\n",
+    "A ``Launcher`` takes a name for the experimental run, the ``Args`` and ``Command`` objects and optional arguments such as the directory to collect results in (here it is ``'output'``) and a chosen limit on the number of concurrent process executed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lancet.Launcher('example', args, gssha_report, output_directory='output', max_concurrency=1)()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This command will take a few minutes to execute, blocking the notebook thread as the batches are being run locally. If ``QLauncher`` were used or another ``Launcher`` based on an HPC batch system, this would return as soon as the jobs are queued."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspecting the results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results are found in timestamped directories within the chosen ``output_directory`` which will be called ``output`` in this instance.\n",
+    "\n",
+    "On Unix systems, you can see this by running the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ls ./output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An example of the report output may be found in a location similar to ``output/2018-06-01_1353-example/example_rain_intensity=24_tid=0.html``. There will be as many such files and directories as batch jobs executed."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,6 @@ cell_timeout = 1800
 
 # notebooks to skip running; one case insensitive re to match per line
 skip_run = ^.*GSSHA.*\.ipynb$
+           ^RainIntensity_Sweep_Example\.ipynb$
 
 nbsmoke_skip_run = ^.*GSSHA.*\.ipynb$

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,5 @@
 cell_timeout = 1800
 
 # notebooks to skip running; one case insensitive re to match per line
-skip_run = ^.*GSSHA.*\.ipynb$
-           ^.*RainIntensity.*\.ipynb$
-
 nbsmoke_skip_run = ^.*GSSHA.*\.ipynb$
-                   ^.*RainIntensity.*\.ipynb$
+                   ^.*Rain_Intensity.*\.ipynb$

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ cell_timeout = 1800
 
 # notebooks to skip running; one case insensitive re to match per line
 skip_run = ^.*GSSHA.*\.ipynb$
-           ^RainIntensity_Sweep_Example\.ipynb$
+           ^.*RainIntensity.*\.ipynb$
 
 nbsmoke_skip_run = ^.*GSSHA.*\.ipynb$
+                   ^.*RainIntensity.*\.ipynb$

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ setup_args = {}
 setup_args.update(dict(
     name='earthsim',
     version="0.1",
-    install_requires = ['lancet'],
     packages = find_packages(),
     entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup_args = {}
 setup_args.update(dict(
     name='earthsim',
     version="0.1",
+    install_requires = ['lancet'],
     packages = find_packages(),
     entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ setup_args.update(dict(
     name='earthsim',
     version="0.1",
     packages = find_packages(),
+    entry_points={
+          'console_scripts': [
+              'param = earthsim.__main__:main'
+          ]}
 ))
 
 if __name__=="__main__":


### PR DESCRIPTION
This PR will add a number of examples to show how notebooks can be parameterized both with widgets for a normal notebook workflow and at the command line. 

These examples are based on the ``GSSHA_Workflow``  notebook, illustrating how two parameters ``rain_intensity`` and ``rain_duration`` can be exposed. The workflow presented allows any parameters to be exposed in this way and also allows new parameters to be defined at the notebook level.

Notes:

* Currently requires a fix available on ``parambokeh`` master regarding ``FileSelector``.
* Some sub-objects have their widgets set in a different cell as parambokeh lacks recursive editing (https://github.com/ioam/parambokeh/issues/58). This is also why the precedence of some parameters was set to -1.
