### PR TITLE
Pin libkml to conda-forge.

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -46,15 +46,15 @@ pyviz/label/earthsim::zeromq
 
 # libkml 1.3.0 build 6 from conda-forge.
 #
-# Note 1: Since we started using this version, it's been marked
-# "broken" (although downloaded >50k times).  However, newer versions
-# require boost 1.67.0, while c-f is pinned to 1.66.0 (and 1.66.0 was
-# used for erdc packages). Appears to be going through some disruptive
-# building changes right now on c-f, so temporarily avoid that by
-# hosting ourselves.
-#
-# Note 2: dependency of libgdal except on win (so by pinning, we're
+# Note 1: dependency of libgdal except on win (so by pinning, we're
 # installing unnecessarily on windows).
+#
+# Note 2: Since we started using this version, it's been marked
+# "broken" (although downloaded >50k times).  However, newest version
+# requires boost 1.67.0, while c-f was previously pinned to 1.66.0
+# (and 1.66.0 was used for erdc packages). Should be able to revert to
+# conda-forge when we update to boost-cpp 1.67.0.
+#
 pyviz/label/earthsim::libkml
 
 ### scipy+deps


### PR DESCRIPTION
Packages have recently changed on defaults and conda-forge, from various ones being labelled 'broken' on conda-forge, to new versions on both. The result is that defaults is now being chosen - at least on linux - also bringing in various other dependencies such as libboost from defaults.

See note in dependencies.txt for full explanation.