### PR TITLE
Add developer dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,9 @@ jobs:
     - &dev_default
       <<: *default
       stage: test
-      before_script: conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
+      before_script:
+        - conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
+        - doit env_capture
 
     - <<: *dev_default
       <<: *_osx_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,29 @@ env:
 
 stages:
   - test
+  - name: user_install
+    if: type = cron
   - name: doc
     if: branch = master AND type != pull_request
 
+_osx_config: &_osx_config
+  os: osx
+  osx_image: xcode9.3
+  env: PYENV_VERSION=3.6.4
+  before_install:
+    # set up python
+    - eval "$(pyenv init -)"
+    - pyenv install $PYENV_VERSION  
+    # check the below still required
+    # brew-installed geos interferes with cartopy?
+    - brew uninstall --ignore-dependencies geos gdal postgis
+
+
 jobs:
   include:
-    ########## TEST DEVELOPER INSTALL ##########
+    ########## TEST USER INSTALL ##########
     - &default
-      stage: test
+      stage: user_install
       before_install: true
       install:
         #####
@@ -37,16 +52,18 @@ jobs:
         - travis_wait 60 doit test_all
 
     - <<: *default
-      os: osx
-      osx_image: xcode9.3
-      env: PYENV_VERSION=3.6.4
-      before_install:
-        # set up python
-        - eval "$(pyenv init -)"
-        - pyenv install $PYENV_VERSION  
-        # check the below still required
-        # brew-installed geos interferes with cartopy?
-        - brew uninstall --ignore-dependencies geos gdal postgis
+      <<: *_osx_config
+
+
+    ########## TEST DEVELOPER INSTALL ##########
+    - &dev_default
+      <<: *default
+      stage: test
+      before_script: conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
+
+    - <<: *dev_default
+      <<: *_osx_config
+
 
     ########## DOCS ##########
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       <<: *default
       stage: test
       before_script:
-        - conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
+        - conda install -c pyviz/label/dev -c conda-forge --file=dependencies-dev-overrides.txt
         - doit env_capture
 
     - <<: *dev_default

--- a/dependencies-dev-overrides.txt
+++ b/dependencies-dev-overrides.txt
@@ -1,0 +1,11 @@
+# Note: if pyviz packages are updated and set new lower bounds on
+# dependencies, may need to add those here (along with channel pins)
+# and update the channel list in the "Developers" section of
+# docs/getting_started/index.rst.
+
+pyviz/label/dev::datashader
+pyviz/label/dev::param
+pyviz/label/dev::parambokeh
+pyviz/label/dev::paramnb
+pyviz/label/dev::holoviews
+pyviz/label/dev::geoviews

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -87,3 +87,14 @@ EarthSim as follows:
 3. Get a new copy of the examples to work on, and download new or updated data::
 
     earthsim examples	 
+
+
+Developers
+----------    
+    
+If you are actively developing EarthSim and want to try out the latest
+pyviz work (which is not necessarily functional or stable), run the
+following after creating or updating your earthsim environment::
+
+  conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
+

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -97,5 +97,5 @@ pyviz work (which is not necessarily functional or stable), run the
 following after creating or updating (and activating) your earthsim
 environment::
 
-  conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
+  conda install -c pyviz/label/dev -c conda-forge --file=dependencies-dev-overrides.txt
 

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -94,7 +94,8 @@ Developers
     
 If you are actively developing EarthSim and want to try out the latest
 pyviz work (which is not necessarily functional or stable), run the
-following after creating or updating your earthsim environment::
+following after creating or updating (and activating) your earthsim
+environment::
 
   conda install -c pyviz/label/dev --file=dependencies-dev-overrides.txt
 


### PR DESCRIPTION
Part of #117. Adds extra dependencies file containing packages from pyviz/label/dev channel. I unfortunately couldn't think of a better way to do this, given all the constraints. Fresh eyes might come up with something better...

Also:
  * Adds travis job to test "developer" as well as "user" installs. Doc building and windows use only the  "user" install (ok?).

Ready to merge from my point of view if tests pass, but depends on review.