### PR TITLE
Shorten the installation command

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
   - "conda install -y -c pyviz/label/dev pyctdev && doit ecosystem_setup"
   - "conda config --set always_yes True"
-  - "conda create -n earthsim -c pyviz/label/earthsim -c conda-forge --file=dependencies.txt conda-forge::python=3.6"
+  - "conda create -n earthsim -c conda-forge --file=dependencies.txt conda-forge::python=3.6"
   - "activate earthsim"
   - "pip install -e ."
   - "doit env_capture"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - conda install -c pyviz/label/dev pyctdev && doit ecosystem_setup
         #####
         - conda config --set path_conflict warn
-        - conda create -n earthsim -c pyviz/label/earthsim -c conda-forge --file=dependencies.txt conda-forge::python=3.6
+        - conda create -n earthsim -c conda-forge --file=dependencies.txt conda-forge::python=3.6
         - source activate earthsim
         - pip install -e .
         - doit env_capture

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -21,7 +21,7 @@ EarthSim itself is a pure Python package that itself would be easy to install, b
 3. Set up an environment with all of the dependencies needed to run the examples::
     
     cd EarthSim
-    conda create -n earthsim -c pyviz/label/earthsim -c conda-forge --file=dependencies.txt conda-forge::python=3.6
+    conda create -n earthsim -c conda-forge --file=dependencies.txt conda-forge::python=3.6
 
 4. Activate the earthsim environment::
 	 


### PR DESCRIPTION
Don't need to specify the pyviz/label/earthsim channel - it's specified where needed in dependencies.txt. 

In contrast, conda-forge is required in the installation command because we need it for some packages that aren't explicitly listed in dependencies.txt.
